### PR TITLE
Roll back minio client version

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,7 +11,7 @@ jobs:
   update_to_mattermost:
     runs-on: ubuntu-latest
     container:
-      image: minio/mc:latest
+      image: minio/mc:RELEASE.2023-10-14T01-57-03Z
     steps:
     - name: List new files and post to Mattermost
       shell: bash


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Latest minio client release doesn't support standard linux commands like grep and awk. Rolling back the version to a previous stable release. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
